### PR TITLE
Fixed custom directive reinsertion (parent is null)

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -8,6 +8,11 @@ export default {
 
     const fragment = document.createDocumentFragment();
     const children = Array.from(element.childNodes);
+
+    if (!element.parentNode) {
+      document.createDocumentFragment().appendChild(element);
+    }
+
     const parent   = element.parentNode;
     const tail     = document.createComment('fragment tail');
 


### PR DESCRIPTION
If our fragment component has no parent, I add one by creating a DocumentFragment. Please note that I have no idea how the rest of the plugin's non-trivial features works (the diff algorithm part, ...): this is a fix based on the local behaviour of the code.

This PR is not meant to be merged in master, considering this is based on an old version of your plugin (1.2.2).

Au plaisir.